### PR TITLE
Add --exclude option for downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ pids
 *.pid
 *.seed
 *.pid.lock
+
+# Other
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Or pass everything directly:
 npx vercel-deploy-source-downloader <token> --deployment aBcxxxxxxxxxxxxxxxxxxxxyZa
 ```
 
+To exclude a path such as `.npm-cache` from download:
+
+```bash
+npx vercel-deploy-source-downloader <token> --deployment aBcxxxxxxxxxxxxxxxxxxxxyZa --exclude .npm-cache
+```
+
 For detailed configuration and advanced usage, see [Documentation](#documentation).
 
 ## Getting Your Vercel Token

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -89,6 +89,16 @@ Use `--verbose` to see detailed output in the console:
 
 Without `--verbose`, the console shows a spinner with download/skip counts and a summary. The log file always contains full details.
 
+## Excluding Paths
+
+Use `--exclude` to skip one or more paths when downloading source files. Paths are matched exactly or by prefix, and can be provided as a comma-separated list.
+
+```bash
+npx vercel-deploy-source-downloader <token> --deployment <id> --exclude .npm-cache,dist
+```
+
+This is useful when you want to avoid downloading caches or generated folders from the deployment source tree.
+
 ## Example Output
 
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ npx vercel-deploy-source-downloader [token] [options]
 | `--project <name>` | Project name | auto-detect |
 | `--team <slug-or-id>` | Team slug (e.g. `numanaral`) or ID (e.g. `team_xxx`) | auto-detect |
 | `--output <path>` | Output directory | `./out` |
+| `--exclude <paths>` | Exclude path(s) from download, comma-separated | off |
 | `--verbose` | Show per-file progress, file tree, and skipped files in console | off |
 | `--retry-failed` | Re-download only files that failed in a previous run | off |
 
@@ -48,6 +49,7 @@ Create a `.env` file (see `.env.example`):
 ```env
 VERCEL_TOKEN=your_token_here
 VERCEL_DEPLOYMENT=aBcxxxxxxxxxxxxxxxxxxxxyZa
+VERCEL_EXCLUDE=.npm-cache,dist
 ```
 
 | Variable | Description | Default |
@@ -56,6 +58,7 @@ VERCEL_DEPLOYMENT=aBcxxxxxxxxxxxxxxxxxxxxyZa
 | `VERCEL_DEPLOYMENT` | Deployment ID or `latest` | `latest` |
 | `VERCEL_PROJECT` | Project name (optional, auto-detected) | — |
 | `VERCEL_TEAM` | Team slug or ID (optional, auto-detected) | — |
+| `VERCEL_EXCLUDE` | Exclude path(s) from download, comma-separated | off |
 | `VERCEL_OUTPUT` | Output directory path | `./out` |
 
 ## Priority Order
@@ -103,4 +106,7 @@ VERCEL_PROJECT=my-project npx vercel-deploy-source-downloader <token>
 
 # Retry only previously failed files
 npx vercel-deploy-source-downloader --deployment <id> --retry-failed
+
+# Exclude `.npm-cache` from download
+npx vercel-deploy-source-downloader <token> --deployment <id> --exclude .npm-cache
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,6 +29,14 @@ npx tsx src/vercel-deploy-source-downloader.ts --deployment <id> --retry-failed
 
 This reads the previous `download-log.txt` and only re-downloads the files that failed.
 
+## Excluding unwanted paths
+
+If you want to skip certain paths from the deployment source tree, use `--exclude`:
+
+```bash
+npx vercel-deploy-source-downloader <token> --deployment <id> --exclude .npm-cache
+```
+
 ## Rate limiting
 
 The tool downloads files sequentially. If you hit rate limits, wait a few minutes and retry (or use `--retry-failed`).

--- a/src/vercel-deploy-source-downloader.ts
+++ b/src/vercel-deploy-source-downloader.ts
@@ -13,6 +13,7 @@
  *   --project <name>     Project name (default: auto-detect from deployment)
  *   --team <slug|id>     Team slug or ID (default: auto-detect from deployment)
  *   --output <path>      Output directory path (default: ./out)
+ *   --exclude <paths>    Exclude path(s) from download, comma-separated
  *   --verbose            Show detailed progress for each file
  *   --retry-failed       Re-download only files that failed in a previous run
  *
@@ -135,6 +136,11 @@ const parseArgs = () => {
 
   const resolvedDeployment = options.deployment || process.env.VERCEL_DEPLOYMENT || "";
   const deploymentExplicitlySet = !!resolvedDeployment;
+  const rawExclude = options.exclude || process.env.VERCEL_EXCLUDE || "";
+  const excludePaths = rawExclude
+    .split(",")
+    .map((path) => path.trim())
+    .filter(Boolean);
 
   // Priority: CLI args > environment variables > defaults
   return {
@@ -146,6 +152,7 @@ const parseArgs = () => {
     output: options.output || process.env.VERCEL_OUTPUT || "./out",
     verbose: options.verbose === "true",
     retryFailed: options["retry-failed"] === "true",
+    excludePaths,
   };
 };
 
@@ -605,6 +612,14 @@ const downloadSource = async () => {
     log("", true);
 
     const token = args.token;
+    const isExcludedPath = (relativeFilePath: string) =>
+      args.excludePaths.some((excludePath) =>
+        excludePath
+          ?
+              relativeFilePath === excludePath ||
+              relativeFilePath.startsWith(`${excludePath}/`)
+          : false
+      );
 
     // Get file tree from API (using base=src for source code)
     log("📋 Fetching file tree from API...", true);
@@ -789,6 +804,11 @@ const downloadSource = async () => {
       const relativeFilePath = relativePath ? `${relativePath}/${node.name}` : node.name;
 
       if (node.type === "directory") {
+        if (isExcludedPath(relativeFilePath)) {
+          log(`⏭️  Excluding directory: ${relativeFilePath}`);
+          return;
+        }
+
         // In retry mode, skip directories that can't contain any failed files
         if (retryOnlyPaths) {
           const dirPrefix = relativeFilePath + "/";
@@ -824,6 +844,11 @@ const downloadSource = async () => {
           }
         }
       } else if (node.type === "file" && node.link) {
+        if (isExcludedPath(relativeFilePath)) {
+          log(`⏭️  Excluding file: ${relativeFilePath}`);
+          return;
+        }
+
         // In retry mode, skip files not in the failed set
         if (retryOnlyPaths && !retryOnlyPaths.has(relativeFilePath)) {
           return;


### PR DESCRIPTION
Introduce an option to exclude specified paths during the download process, allowing users to skip unwanted directories or files. This enhances flexibility and efficiency when managing source downloads.